### PR TITLE
Fix missing db import in create_app

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,10 +1,8 @@
 from flask import Flask
-from flask_login import LoginManager
+from .extensions import db, login_manager
 from .models import User
 from .routes import bp
 from config import Config
-
-login_manager = LoginManager()
 
 def create_app():
     app = Flask(__name__)


### PR DESCRIPTION
## Summary
- import the shared SQLAlchemy object in `create_app`

## Testing
- `pytest -q` *(fails: command not found)*