### PR TITLE
Fix index route registration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -25,6 +25,8 @@ def create_app():
     from .auth import auth_bp
     from .admin import admin_bp
     from .user import user_bp
+    # Register the main blueprint containing the index route
+    app.register_blueprint(bp)
     app.register_blueprint(auth_bp)
     app.register_blueprint(admin_bp)
     app.register_blueprint(user_bp)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,13 @@
+import pytest
+from app import create_app
+from flask.testing import FlaskClient
+
+
+def test_index_route_returns_200():
+    app = create_app()
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        response = client.get('/')
+        assert response.status_code == 200
+        assert b'Food Pantry' in response.data or b'Hello' in response.data
+


### PR DESCRIPTION
## Summary
- register the main blueprint in `create_app`
- add a test to ensure `/` works

## Testing
- `pytest -q` *(fails: command not found)*
- `python -m pytest -q` *(fails: No module named pytest)*