### PR TITLE
Fix test import error

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,15 @@
+import os
+import sys
 import pytest
 from flask import Flask
 from flask_login import LoginManager
+
+# Ensure the project root is on ``sys.path`` so imports work when tests are run
+# from different working directories.
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
 from models import db, User
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- modify `tests/conftest.py` to add the project root to `sys.path`

## Testing
- `pytest -q` *(fails: command not found)*